### PR TITLE
消除视频抖动的尝试

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -100,7 +100,7 @@ if __name__ == '__main__':
     parser.add_argument("--checkpoint_dir", default='./checkpoints', help="path to output")
     parser.add_argument("--result_dir", default='./results', help="path to output")
     parser.add_argument("--batch_size", type=int, default=1, help="the batch size of facerender")
-    parser.add_argument("--enhancer", type=str, default='lip', help="enhaner region:[none,lip,face] \
+    parser.add_argument("--enhancer", type=str, default='none', help="enhaner region:[none,lip,face] \
                                                                       none:do not enhance; \
                                                                       lip:only enhance lip region \
                                                                       face: enhance (skin nose eye brow lip) region")

--- a/src/facerender/modules/make_animation.py
+++ b/src/facerender/modules/make_animation.py
@@ -122,7 +122,7 @@ def make_animation(source_image, source_semantics, target_semantics, generator, 
             he_driving = mapping(target_semantics_frame)
             kp_driving = keypoint_transformation(kp_canonical[frame_idx], he_driving)
             kp_norm = kp_driving
-            out = generator(source_image[frame_idx], kp_source=kp_source[frame_idx], kp_driving=kp_norm)
+            out = generator(source_image[0], kp_source=kp_source[0], kp_driving=kp_norm)
             predictions.append(out['prediction'])
         predictions_ts = torch.stack(predictions, dim=1)
     return predictions_ts


### PR DESCRIPTION
分析抖动由两个方面引起：

原因1. 在送给face-vid2vid的参数里面，beta分支中将每一帧作为source帧送给generator，会引起抖动
原因2. face-vid2vid会天然有面部的抖动，如果贴回的话，会引起抖动。可以先直出，然后后续接超分增强

注意受限于face-vid2vid，身体还会有一些微动，预计需要额外对generator网络做一些特殊处理